### PR TITLE
Add a new endpoint where tool usage events can be logged from steps

### DIFF
--- a/models/tool_analytics.go
+++ b/models/tool_analytics.go
@@ -1,0 +1,8 @@
+package models
+
+// ToolAnalytics ...
+type ToolAnalytics struct {
+	BuildSlug string `json:"build_slug"`
+
+	ToolUsage []ToolUsage `json:"tool_usage"`
+}

--- a/models/tool_usage.go
+++ b/models/tool_usage.go
@@ -1,0 +1,24 @@
+package models
+
+// ToolUsage ...
+type ToolUsage struct {
+	BuildSlug    string `json:"-" track:"build_slug"`
+	Name         string `json:"name" track:"name"`
+	Version      string `json:"version" track:"version"`
+	FreshInstall bool   `json:"fresh_install" track:"fresh_install"`
+}
+
+// Event ...
+func (a ToolUsage) Event() string {
+	return "tool_used"
+}
+
+// Model ...
+func (a ToolUsage) Model() interface{} {
+	return a
+}
+
+// UserID ...
+func (a ToolUsage) UserID() string {
+	return a.BuildSlug
+}

--- a/router/router.go
+++ b/router/router.go
@@ -21,6 +21,8 @@ func New(config configs.ConfigModel) *mux.Router {
 		httpresponse.InternalErrHandlerFuncAdapter(service.MetricsPostHandler))).Methods("POST")
 	r.Handle("/logs", middlewareProvider.MiddlewareWithClient().Then(
 		httpresponse.InternalErrHandlerFuncAdapter(service.CustomLogsPostHandler))).Methods("POST")
+	r.Handle("/tools", middlewareProvider.MiddlewareWithClient().Then(
+		httpresponse.InternalErrHandlerFuncAdapter(service.ToolsPostHandler))).Methods("POST")
 
 	return r
 }

--- a/service/tools_post.go
+++ b/service/tools_post.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"encoding/json"
+	"github.com/bitrise-io/api-utils/httpresponse"
+	"github.com/bitrise-io/bitrise-step-analytics/models"
+	"github.com/pkg/errors"
+	"net/http"
+)
+
+// ToolsPostHandler ...
+func ToolsPostHandler(w http.ResponseWriter, r *http.Request) error {
+	var toolAnalytics models.ToolAnalytics
+	defer httpresponse.RequestBodyCloseWithErrorLog(r)
+	if err := json.NewDecoder(r.Body).Decode(&toolAnalytics); err != nil {
+		return httpresponse.RespondWithBadRequestError(w, "Invalid request body, JSON decode failed")
+	}
+
+	if toolAnalytics.BuildSlug == "" {
+		return httpresponse.RespondWithBadRequestError(w, "Invalid request body, please provide build_slug")
+	}
+	if len(toolAnalytics.ToolUsage) < 1 {
+		return httpresponse.RespondWithBadRequestError(w, "Invalid request body, please provide at least one tool_usage")
+	}
+	for _, toolUsage := range toolAnalytics.ToolUsage {
+		if toolUsage.Name == "" {
+			return httpresponse.RespondWithBadRequestError(w, "Invalid request body, please fill name for tool_usage")
+		}
+	}
+
+	segmentClient, err := GetClientFromContext(r.Context())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for _, toolUsage := range toolAnalytics.ToolUsage {
+		toolUsage.BuildSlug = toolAnalytics.BuildSlug
+		segmentClient.Track(toolUsage)
+	}
+
+	return httpresponse.RespondWithSuccess(w, map[string]string{"message": "ok"})
+}

--- a/service/tools_post_test.go
+++ b/service/tools_post_test.go
@@ -1,0 +1,93 @@
+package service_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-step-analytics/service"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ToolsPostHandler(t *testing.T) {
+	handler := service.ToolsPostHandler
+
+	for _, tc := range []struct {
+		testName            string
+		requestBody         string
+		expectedInternalErr string
+		expectedBody        string
+		expectedLogContent  map[string]interface{}
+		expectedStatusCode  int
+	}{
+		{
+			testName: "ok, minimal",
+			requestBody: `{` +
+				`"build_slug":"build-slug"` +
+				`,"tool_usage":[` +
+				`{"name":"test-tool","version":"1.2.3","fresh_install":false}` +
+				`,{"name":"test-tool-2","version":"1.2.3","fresh_install":true}` +
+				`]` +
+				`}`,
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       `{"message":"ok"}` + "\n",
+		},
+		{
+			testName: "when no tool usage provided ",
+			requestBody: `{` +
+				`"build_slug":"build-slug"` +
+				`}`,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"message":"Invalid request body, please provide at least one tool_usage"}` + "\n",
+		},
+		{
+			testName: "when no name provided for a tool",
+			requestBody: `{` +
+				`"build_slug":"build-slug"` +
+				`,"tool_usage":[` +
+				`{"version":"1.2.3","fresh_install":false}` +
+				`,{"name":"test-tool-2","version":"1.2.3","fresh_install":true}` +
+				`]` +
+				`}`,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"message":"Invalid request body, please fill name for tool_usage"}` + "\n",
+		},
+		{
+			testName:           "when no request body provided",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"message":"Invalid request body, JSON decode failed"}` + "\n",
+		},
+		{
+			testName:           "when no tools data provided",
+			requestBody:        `{}`,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBody:       `{"message":"Invalid request body, please provide build_slug"}` + "\n",
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			r, err := http.NewRequest("POST", "/tools", bytes.NewBuffer([]byte(tc.requestBody)))
+			require.NoError(t, err)
+
+			r = r.WithContext(service.ContextWithClient(r.Context(), &testClient{}))
+
+			rr := httptest.NewRecorder()
+			internalServerError := handler(rr, r)
+
+			if tc.expectedBody != "" {
+				require.Equal(t, tc.expectedBody, rr.Body.String())
+			}
+
+			if tc.expectedInternalErr != "" {
+				require.EqualError(t, internalServerError, tc.expectedInternalErr,
+					"Expected internal err: %s | Request Body: %s | Response Code: %d, Expected Response Body: %s | Got Body: %s", tc.expectedInternalErr, tc.requestBody, rr.Code, tc.expectedBody, rr.Body.String())
+			} else {
+				require.NoError(t, internalServerError)
+				if tc.expectedStatusCode != 0 {
+					require.Equal(t, tc.expectedStatusCode, rr.Code,
+						"Expected body: %s | Got body: %s", tc.expectedBody, rr.Body.String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
We'd like to track the used / installed steps during a workflow so we
can prepare our VMs better for real life usage.

* Added new endpoint
* Added new event structure
* Added test cases

[STEP-381]

[STEP-381]: https://bitrise.atlassian.net/browse/STEP-381