### PR TITLE
Add step_finished metrics for step failure monitoring

### DIFF
--- a/stepmetrics/stepmetrics.go
+++ b/stepmetrics/stepmetrics.go
@@ -21,6 +21,8 @@ func CreateMetricsFromEvent(client *statsd.Client, event models.TrackEvent) {
 		cliToolSetup(client, event)
 	case "cli_step_activation":
 		cliStepActivation(client, event)
+	case "step_finished":
+		stepFinished(client, event)
 	}
 }
 
@@ -125,5 +127,19 @@ func cliStepActivation(client *statsd.Client, event models.TrackEvent) {
 	duration := event.IntProp("duration_ms")
 	if duration != 0 {
 		_ = client.Histogram("cli_step_activation_duration", float64(duration), tags, 1)
+	}
+}
+
+// Schema: https://github.com/bitrise-io/data-events/blob/main/schemas/data-team-229312/events/step_finished.json
+func stepFinished(client *statsd.Client, event models.TrackEvent) {
+	tags := []string{
+		"status:" + event.StringProp("status"),
+	}
+
+	_ = client.Incr("step_finished_total", tags, 1)
+
+	runtime := event.IntProp("runtime")
+	if runtime != 0 {
+		_ = client.Histogram("step_runtime_seconds", float64(runtime), tags, 1)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `step_finished_total` (counter) and `step_runtime_seconds` (histogram) metrics, tagged by `status`, sourced from the [`step_finished`](https://github.com/bitrise-io/data-events/blob/main/schemas/data-team-229312/events/step_finished.json) event.
- Goal: alert on sudden spikes in step failure rate via Datadog.

## Known limitation — no per-step breakdown (intentional)
`step_finished` currently only carries `step_execution_id`, not `step_id`/`step_title`. That means these metrics show fleet-wide failure rate, not "which step is failing."

This was left out intentionally rather than joined against `step_started` in this service (which processes events independently, not as a stream). If we agree the cardinality of adding `step_id` as a tag is acceptable, the right fix is to extend the `step_finished` event schema to include it — happy to follow up on that once confirmed.

## Test plan
- [x] `go build ./...` / `go vet ./stepmetrics/...` pass
- [ ] Verify real `status` values in production events match expected tag values
- [ ] Confirm metrics show up in Datadog once deployed