### PR TITLE
Tag cli_step_activation metrics with inventory_source

### DIFF
--- a/stepmetrics/stepmetrics.go
+++ b/stepmetrics/stepmetrics.go
@@ -102,10 +102,18 @@ func cliToolSetup(client *statsd.Client, event models.TrackEvent) {
 	_ = client.Incr("cli_tool_setup", tags, 1)
 }
 
+// Schema: https://github.com/bitrise-io/data-events/blob/main/schemas/data-team-229312/events/cli_step_activation.json
 func cliStepActivation(client *statsd.Client, event models.TrackEvent) {
 	tags := []string{
 		"activation_type:" + event.StringProp("activation_type"),
 		"cli_version:" + event.StringProp("cli_version"),
+	}
+
+	// Which StepLib inventory served the step: "steplib_api" or "steplib". Only
+	// steplib refs have one, so it is absent for git and path refs — tagged only
+	// when present, to avoid an empty tag value on those.
+	if inventorySource := event.StringProp("inventory_source"); inventorySource != "" {
+		tags = append(tags, "inventory_source:"+inventorySource)
 	}
 
 	isSuccessful, err := event.BoolProp("is_successful")


### PR DESCRIPTION
## Why

The CLI now reports which StepLib inventory served an activation — `steplib_api` or `steplib` — on `cli_step_activation` ([bitrise#1297], [STEP-2421]).

BigQuery gets it for free: `tracker.Send` passes every property through, and the columns are declared in [data-events#110] (merged). But the Datadog tag list in `cliStepActivation` is hardcoded, so `cli_step_activation` and `cli_step_activation_duration` could not be split by API vs legacy — the split the rollout needs to watch in real time.

## What

Tags `inventory_source` when the property is present. Only steplib refs have an inventory, and `StringProp` returns `""` for a missing key, so git and path refs would otherwise carry a dangling `inventory_source:` tag. Follows the existing `status_code != 0` pattern in `appStoreConnectRequests`.

Cardinality ≤3×, against a tag set that already includes `cli_version`.

**Not tagged:** `step_execution_id`, the other new property on this event — a per-execution UUID, unbounded cardinality. It exists for the BigQuery join with `cli_toolkit_prepare`.

Also added the `// Schema:` link comment every other handler in this file has.

## Tests

`go build ./...`, `go vet ./...`, `go test ./...` pass.

No test for the tag list, matching the two prior changes to these handlers (#55, #62) — the package's only test covers `normalizeEndpoint`, and these handlers take a `*statsd.Client` with no seam. Happy to extract a testable tag-builder if you'd rather have coverage.

`gofmt -l` flags `stepmetrics.go` on `master` (the `trackedSteps` map from #62); left untouched to keep this diff to one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2421]: https://bitrise.atlassian.net/browse/STEP-2421
[bitrise#1297]: https://github.com/bitrise-io/bitrise/pull/1297
[data-events#110]: https://github.com/bitrise-io/data-events/pull/110
