### PR TITLE
Log failed activations so Datadog can reach the build

### DIFF
--- a/stepmetrics/stepmetrics.go
+++ b/stepmetrics/stepmetrics.go
@@ -1,13 +1,47 @@
 package stepmetrics
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/bitrise-io/bitrise-step-analytics/models"
 )
+
+// jsonLogger writes structured lines with no prefix. The package-level log.Println prepends
+// "2026/07/31 09:15:27 ", and Datadog only auto-parses a log body that is *entirely* valid
+// JSON — a timestamp in front would leave every field as unparsed text and no @build_slug
+// facet would exist. Destination is stderr to match the existing log calls in this file,
+// whose collection into Datadog is already proven.
+var jsonLogger = log.New(os.Stderr, "", 0)
+
+// logJSON writes fields as a single-line JSON log. Datadog parses JSON log bodies into
+// attributes, so every key becomes a queryable facet (@build_slug, @step_ref, ...). That is
+// why these identifiers belong in logs rather than metric tags: build_slug is unbounded
+// cardinality and would blow up the metric, but costs nothing here.
+func logJSON(fields map[string]any) {
+	// Drop empty strings so a facet's presence is meaningful: a CLI older than v2.42.2 sends
+	// no step_execution_id, and emitting it as "" would make @step_execution_id:* match every
+	// log line instead of only the ones that can be joined to their failure reason. Only
+	// empty strings are dropped — a numeric zero can be a real measurement.
+	present := make(map[string]any, len(fields))
+	for k, v := range fields {
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		present[k] = v
+	}
+
+	line, err := json.Marshal(present)
+	if err != nil {
+		log.Printf("failed to marshal log fields: %s", err)
+		return
+	}
+	jsonLogger.Println(string(line))
+}
 
 func CreateMetricsFromEvent(client *statsd.Client, event models.TrackEvent) {
 	_ = client.Incr("events", []string{}, 1)
@@ -23,6 +57,8 @@ func CreateMetricsFromEvent(client *statsd.Client, event models.TrackEvent) {
 		cliStepActivation(client, event)
 	case "step_finished":
 		stepFinished(client, event)
+	case "step_preparation_failed":
+		stepPreparationFailed(event)
 	}
 }
 
@@ -112,7 +148,8 @@ func cliStepActivation(client *statsd.Client, event models.TrackEvent) {
 	// Which StepLib inventory served the step: "steplib_api" or "steplib". Only
 	// steplib refs have one, so it is absent for git and path refs — tagged only
 	// when present, to avoid an empty tag value on those.
-	if inventorySource := event.StringProp("inventory_source"); inventorySource != "" {
+	inventorySource := event.StringProp("inventory_source")
+	if inventorySource != "" {
 		tags = append(tags, "inventory_source:"+inventorySource)
 	}
 
@@ -121,6 +158,15 @@ func cliStepActivation(client *statsd.Client, event models.TrackEvent) {
 		tags = append(tags, fmt.Sprintf("is_successful:%t", isSuccessful))
 	} else {
 		log.Println("'is_successful' property of 'cli_step_activation' is not a bool")
+	}
+
+	// A failed activation is logged as well as counted: the metric cannot carry
+	// build_slug (unbounded cardinality), so without this there is no way to get from
+	// the Datadog failure count to the build that failed. Only on a parsed false —
+	// BoolProp yields (false, err) for a missing or non-bool property, and those are
+	// unknown outcomes rather than failures.
+	if err == nil && !isSuccessful {
+		logJSON(failedActivationLogFields(event))
 	}
 
 	isCI, err := event.BoolProp("is_ci")
@@ -135,6 +181,45 @@ func cliStepActivation(client *statsd.Client, event models.TrackEvent) {
 	duration := event.IntProp("duration_ms")
 	if duration != 0 {
 		_ = client.Histogram("cli_step_activation_duration", float64(duration), tags, 1)
+	}
+}
+
+// failedActivationLogFields is the log payload for a failed activation. Split out from
+// cliStepActivation because these key names are the contract the Datadog facets are built
+// on: renaming one silently breaks every saved query and dashboard link using it.
+func failedActivationLogFields(event models.TrackEvent) map[string]any {
+	return map[string]any{
+		"event":             "cli_step_activation_failed",
+		"build_slug":        event.StringProp("build_slug"),
+		"step_execution_id": event.StringProp("step_execution_id"),
+		"step_ref":          event.StringProp("step_ref"),
+		"activation_type":   event.StringProp("activation_type"),
+		"inventory_source":  event.StringProp("inventory_source"),
+		"cli_version":       event.StringProp("cli_version"),
+		"duration_ms":       event.IntProp("duration_ms"),
+	}
+}
+
+// Schema: https://github.com/bitrise-io/data-events/blob/main/schemas/data-team-229312/events/step_preparation_failed.json
+//
+// Logged, not counted. This event carries the error_message that cli_step_activation lacks,
+// so joining the two on step_execution_id turns a failure count into a cause. step_finished
+// already counts failures, so a second metric here would only duplicate it.
+func stepPreparationFailed(event models.TrackEvent) {
+	logJSON(preparationFailedLogFields(event))
+}
+
+// preparationFailedLogFields is the other half of the drill-down. It has no build_slug —
+// the event does not carry one — which is why this is a separate log line joined on
+// step_execution_id rather than extra fields on the activation log.
+func preparationFailedLogFields(event models.TrackEvent) map[string]any {
+	return map[string]any{
+		"event":                 "step_preparation_failed",
+		"step_execution_id":     event.StringProp("step_execution_id"),
+		"workflow_execution_id": event.StringProp("workflow_execution_id"),
+		"step_id":               event.StringProp("step_id"),
+		"step_version":          event.StringProp("step_version"),
+		"error_message":         event.StringProp("error_message"),
 	}
 }
 

--- a/stepmetrics/stepmetrics_test.go
+++ b/stepmetrics/stepmetrics_test.go
@@ -1,11 +1,89 @@
 package stepmetrics
 
 import (
+	"bytes"
+	"encoding/json"
+	"log"
 	"strings"
 	"testing"
 
+	"github.com/bitrise-io/bitrise-step-analytics/models"
 	"github.com/stretchr/testify/require"
 )
+
+// The log-field tests below assert exact maps rather than substrings: the keys become Datadog
+// log facets (@build_slug, @step_execution_id, ...), so renaming one silently breaks every
+// saved query and dashboard link built on it. require.Equal on the whole map also catches an
+// accidentally added or dropped key, which a per-key assertion would not.
+
+func Test_failedActivationLogFields(t *testing.T) {
+	event := models.TrackEvent{
+		EventName: "cli_step_activation",
+		Properties: map[string]any{
+			"build_slug":        "45d53f84-351d-488b-a22b-59794f759531",
+			"step_execution_id": "7f3a1c92-0000-4aaa-bbbb-ccccdddd0001",
+			"step_ref":          "deploy-to-bitrise-io",
+			"activation_type":   "steplib_source",
+			"inventory_source":  "steplib_api",
+			"cli_version":       "2.42.2",
+			"duration_ms":       float64(217), // JSON numbers decode as float64
+			"is_successful":     false,
+		},
+	}
+
+	require.Equal(t, map[string]any{
+		"event":             "cli_step_activation_failed",
+		"build_slug":        "45d53f84-351d-488b-a22b-59794f759531",
+		"step_execution_id": "7f3a1c92-0000-4aaa-bbbb-ccccdddd0001",
+		"step_ref":          "deploy-to-bitrise-io",
+		"activation_type":   "steplib_source",
+		"inventory_source":  "steplib_api",
+		"cli_version":       "2.42.2",
+		"duration_ms":       217,
+	}, failedActivationLogFields(event))
+}
+
+// A CLI older than v2.42.2 sends neither step_execution_id nor inventory_source. Those
+// activations are still worth logging: build_slug is present, so the failure is still
+// traceable to a build even though it cannot be joined to its reason.
+func Test_failedActivationLogFields_missingPropertiesAreEmpty(t *testing.T) {
+	event := models.TrackEvent{
+		EventName: "cli_step_activation",
+		Properties: map[string]any{
+			"build_slug": "af4a4b03-40af-4b4a-a637-5b9ac28432fe",
+			"step_ref":   "deploy-to-bitrise-io",
+		},
+	}
+
+	fields := failedActivationLogFields(event)
+
+	require.Equal(t, "af4a4b03-40af-4b4a-a637-5b9ac28432fe", fields["build_slug"])
+	require.Equal(t, "", fields["step_execution_id"])
+	require.Equal(t, "", fields["inventory_source"])
+	require.Equal(t, 0, fields["duration_ms"])
+}
+
+func Test_preparationFailedLogFields(t *testing.T) {
+	event := models.TrackEvent{
+		EventName: "step_preparation_failed",
+		Properties: map[string]any{
+			"step_execution_id":     "7f3a1c92-0000-4aaa-bbbb-ccccdddd0001",
+			"workflow_execution_id": "9b2e4d51-0000-4eee-ffff-000011112222",
+			"step_id":               "deploy-to-bitrise-io",
+			"step_version":          "1",
+			"error_message":         "Preparing Step (deploy-to-bitrise-io@1) failed: resolve step version",
+		},
+	}
+
+	require.Equal(t, map[string]any{
+		"event":                 "step_preparation_failed",
+		"step_execution_id":     "7f3a1c92-0000-4aaa-bbbb-ccccdddd0001",
+		"workflow_execution_id": "9b2e4d51-0000-4eee-ffff-000011112222",
+		"step_id":               "deploy-to-bitrise-io",
+		"step_version":          "1",
+		"error_message":         "Preparing Step (deploy-to-bitrise-io@1) failed: resolve step version",
+	}, preparationFailedLogFields(event))
+}
 
 func Test_normalizeEndpoint(t *testing.T) {
 	tests := []struct {
@@ -80,4 +158,33 @@ func Test_normalizeEndpoint(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// The whole drill-down depends on Datadog auto-parsing the body as JSON, which requires the
+// emitted line to be valid JSON with nothing prepended — log.Println would prefix a
+// timestamp and silently defeat it. Empty strings are dropped so that @step_execution_id:*
+// selects only the failures that can be joined to a reason.
+func Test_logJSON_emitsBareJSONAndOmitsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	orig := jsonLogger
+	jsonLogger = log.New(&buf, "", 0)
+	defer func() { jsonLogger = orig }()
+
+	logJSON(failedActivationLogFields(models.TrackEvent{
+		Properties: map[string]any{"build_slug": "abc", "duration_ms": float64(0)},
+	}))
+
+	line := strings.TrimRight(buf.String(), "\n")
+	require.True(t, strings.HasPrefix(line, "{"), "must be bare JSON, got: %q", line)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &parsed), "must be valid JSON: %q", line)
+
+	require.Equal(t, "cli_step_activation_failed", parsed["event"])
+	require.Equal(t, "abc", parsed["build_slug"])
+	// Absent, not empty — this is what makes the facet filter usable.
+	require.NotContains(t, parsed, "step_execution_id")
+	require.NotContains(t, parsed, "inventory_source")
+	// A zero measurement is kept: only empty strings are dropped.
+	require.Equal(t, float64(0), parsed["duration_ms"])
 }


### PR DESCRIPTION
## Why

The **Failed activations** widget ([Mobile Domain metrics](https://app.datadoghq.com/dashboard/zai-wxj-sr5)) counts failures but gives no way to reach the build that failed, or the reason. `build_slug` cannot become a metric tag — unbounded cardinality — so the metric can never answer it.

Logs have no cardinality limit, and **this service's output is already collected into Datadog** (confirmed: the existing `log.Println` calls in `stepmetrics.go` arrive tagged `service:step-analytics env:production`). So two log lines close the gap with no CLI change, no schema change, no infra work.

## What

- `logJSON` helper — JSON so Datadog auto-parses the body into attributes, making each key a queryable facet.
- Failed `cli_step_activation` → logs `build_slug`, `step_execution_id`, `step_ref`, `activation_type`, `inventory_source`, `cli_version`, `duration_ms`.
- New `step_preparation_failed` case → logs `step_execution_id`, `workflow_execution_id`, `step_id`, `step_version`, `error_message`. **Logged, not counted** — `step_finished` already counts failures.

Two lines rather than one because the halves live on different events: `cli_step_activation` has `build_slug` but no error; `step_preparation_failed` has the error but no `build_slug`. Joined on `step_execution_id`, mirroring the BigQuery join.

### Two subtleties worth reviewing

**Prefix-free logger.** The package-level `log.Println` prepends `2026/07/31 09:15:27 `, and Datadog only auto-parses a body that is *entirely* valid JSON. A timestamp in front would leave every field as unparsed text and no `@build_slug` facet would exist — the failure mode would have been silent. `jsonLogger` writes to stderr with no flags, matching the destination whose collection is already proven. Covered by `Test_logJSON_emitsBareJSONAndOmitsEmpty`.

**Empty strings dropped.** A CLI older than v2.42.2 sends no `step_execution_id`. Emitting `""` would make `@step_execution_id:*` match every line instead of only the joinable ones. Numeric zeros are kept — a 0 ms duration is a real measurement.

**Guarded on a parsed `false`.** `BoolProp` returns `(false, err)` for a missing or non-bool property, so `!isSuccessful` alone would log every unparseable event as a failure.

## Usage

```
service:step-analytics @event:cli_step_activation_failed
service:step-analytics @event:step_preparation_failed @step_execution_id:<id>
```

Build URL: `https://app.bitrise.io/build/<build_slug>`.

## Coverage (measured, 24h)

| | total failed | has `build_slug` | has `step_execution_id` |
|---|---|---|---|
| `is_ci:true` | 165 | **164 (99.4%)** | 16 (9.7%) |
| `is_ci:false` | 22 | 0 | 0 |

So the build link works for ~all CI failures immediately; the link to the *reason* fills in as v2.42.2 rolls out. Local runs have no build to link to at all.

Volume is negligible — ~14-190 failures/day.

## Tests

`go build ./...`, `go vet ./...`, `go test ./...` pass. Four new tests. The field maps are extracted into pure functions and asserted whole, because those key names are the contract the Datadog facets depend on — that is the testable seam #55 and #62 lacked.

`gofmt -l` still flags `stepmetrics.go` for the pre-existing `trackedSteps` block from #62; left untouched to keep this diff to one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)